### PR TITLE
Prevent occasional hibernate session errors during run-seed.

### DIFF
--- a/scripts/RunSeed.groovy
+++ b/scripts/RunSeed.groovy
@@ -3,6 +3,9 @@ includeTargets << grailsScript("_GrailsBootstrap")
 target(runSeed: "Installs seed files") {
 	depends(configureProxy,compile, packageApp, bootstrap)
 
+    def persistenceInterceptor = appCtx.containsBean('persistenceInterceptor') ? appCtx.persistenceInterceptor : null
+    persistenceInterceptor?.init()
+
 	appCtx.seedService.installSeedData()
 }
 


### PR DESCRIPTION
In grails 2.3.5, I was running into the occasional "No Hibernate Session bound
to thread, and configuration does not allow creation of non-transactional one
here" exception when executing the run-seed task.  By forcing initialization of
the `persistenceInterceptor`, we can prevent those exceptions.
