### PR TITLE
Changes to enable executing named Seed from within the seedFiles found on the path.

### DIFF
--- a/src/seed/test/SomeDomainObjectSeed.groovy
+++ b/src/seed/test/SomeDomainObjectSeed.groovy
@@ -1,0 +1,5 @@
+println "Seeding test someDomainObject"
+seed  = {
+    someDomainObject(meta:[key:'code'],code:'a',something:'5678')
+    someDomainObject(meta:[key:'code'],code:'b',something:'5679')
+}

--- a/src/seed/test/SomeOtherDomainObjectSeed.groovy
+++ b/src/seed/test/SomeOtherDomainObjectSeed.groovy
@@ -1,0 +1,5 @@
+println "Seeding test someOtherDomainObject"
+seed  = {
+    someOtherDomainObject(meta:[key:'extId'],extId:'1',somethingElse:'foo')
+    someOtherDomainObject(meta:[key:'extId'],extId:'2',somethingElse:'bar')
+}

--- a/test/unit/seedme/SeedServiceTests.groovy
+++ b/test/unit/seedme/SeedServiceTests.groovy
@@ -1,0 +1,76 @@
+package seedme
+
+import grails.test.mixin.domain.DomainClassUnitTestMixin
+
+import static org.junit.Assert.*
+import grails.test.mixin.TestFor
+import grails.test.mixin.*
+
+class SomeDomainObject {
+
+    String id;
+    String version;
+
+    String code
+    String something
+    Date dateCreated
+    Date lastUpdated
+}
+
+class SomeOtherDomainObject {
+    String id;
+    String version;
+
+    String extId
+    String somethingElse
+    Date dateCreated
+    Date lastUpdated
+
+}
+
+/**
+ * See the API for {@link grails.test.mixin.support.GrailsUnitTestMixin} for usage instructions
+ */
+@TestFor(SeedService)
+@TestMixin(DomainClassUnitTestMixin)
+class SeedServiceTests {
+
+    def testInstallSeedData() {
+        mockDomain(SeedMeChecksum)
+        mockDomain(SomeDomainObject)
+        mockDomain(SomeOtherDomainObject)
+
+        def someDomains = SomeDomainObject.findAll();
+        def someOtherDomains = SomeOtherDomainObject.findAll()
+        assertEquals(0, someDomains.size())
+        assertEquals(0, someOtherDomains.size())
+
+        service.installSeedData()
+
+        someDomains = SomeDomainObject.findAll();
+        someOtherDomains = SomeOtherDomainObject.findAll()
+        assertEquals(2, someDomains.size())
+        assertEquals(2, someOtherDomains.size())
+
+    }
+
+    def testInstallNamedSeed() {
+        mockDomain(SeedMeChecksum)
+        mockDomain(SomeDomainObject)
+        mockDomain(SomeOtherDomainObject)
+
+        def someDomains = SomeDomainObject.findAll();
+        def someOtherDomains = SomeOtherDomainObject.findAll()
+        assertEquals(0, someDomains.size())
+        assertEquals(0, someOtherDomains.size())
+
+        service.installSeedData("application.SomeDomainObjectSeed")
+
+        someDomains = SomeDomainObject.findAll();
+        someOtherDomains = SomeOtherDomainObject.findAll()
+        assertEquals(2, someDomains.size())
+        assertEquals(0, someOtherDomains.size())
+
+    }
+
+}


### PR DESCRIPTION
Tests included.
This is useful for my integrationTests where I would like to share datasource state between test classes without needing to install all seed data. 
Handles seed references by SeedName and PluginName.SeedName in same way as the dependency resolver.  However, I found I needed to convert from PluginName to plugin-name in order to find the correct reference. 
