### PR TITLE
Remove usage of deprecated Grails Domain Class API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "com.jfrog.bintray" version "1.6"
 }
 
-version "3.1.6"
+version "3.3.0"
 group "com.bertramlabs.plugins"
 
 apply plugin:"eclipse"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.1.5
+grailsVersion=3.3.0
 gradleWrapperVersion=2.13

--- a/src/main/groovy/seedme/SeedMeGrailsPlugin.groovy
+++ b/src/main/groovy/seedme/SeedMeGrailsPlugin.groovy
@@ -5,7 +5,7 @@ import grails.plugins.*
 class SeedMeGrailsPlugin extends Plugin {
 
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "3.1.5 > *"
+    def grailsVersion = "3.3.0 > *"
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
         "grails-app/views/error.gsp"


### PR DESCRIPTION
See
http://docs.grails.org/3.3.0/guide/upgrading.html#_grails_domain_class_api_deprecated

Deprecated in 3.3.x this API has been removed entirely from Grails 4
rendering SeedMe unworkable with that version of Grails.  These
changes are compatible with Grails versions >= 3.3.0, including Grails
4, so hopefully the version bump to 3.3.0 of this plugin is a helpful
reminder.